### PR TITLE
added missing library

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -115,6 +115,7 @@ There are lots of ways that we might add a tooltip.  `gridSVG` on its own can ea
 
 ```{r fig.keep='none'}
 require(gridSVG)
+require(XML)
 #print our ggplot2 graphic again
 g4
 #export to SVG file and R object


### PR DESCRIPTION
I found that I needed `XML` for `saveXML`. 

But the bigger puzzle for me is how you get your figure that appears directly after `cat(saveXML(g4.svg$svg))` to have mouseover tooltips, which is really interesting. When I render this Rmd in RStudio, I get everything looking the same (though there seems to be something missing after 'This is the supporting website for his book'), but no tooltips (viewing in Chrome and Firefox). 

I'm not really sure what to do with all the Javascript, any tips you have on that would be much appreciated, thanks!
